### PR TITLE
Update 2-os_concept.tex

### DIFF
--- a/slides/2-os_concept.tex
+++ b/slides/2-os_concept.tex
@@ -209,7 +209,7 @@
       \item In which situation a file tree would last for a few minutes? % Temporary files
       \item How to recognize a virus permission? % read the slides, and think a little bit
       \item What is the condition for N files to have the same name? % be in N different directories
-      \item What is the condition for N files to have the same absolut path? % To be the same file
+      \item What is the condition for N files to have the same absolute path? % To be the same file
       \item Why does a mounting point should be empty? % otherwise stored files are not accessible anymore
       \item Why a system would need \emph{virtual} memory? % because physical memory cost a lot while requiring more memory and because virtual memory is not volatile (for example RAM to SWAP when hibernating your OS)
     \end{itemize}


### PR DESCRIPTION
correcting the correction

Unless you meant absolut as in Absolut Vodka, the correct word is "absolute", poke @shark-oxi 
